### PR TITLE
fix: remove lookup for states

### DIFF
--- a/coreff_creditsafe/mixins/creditsafe_data_mixin.py
+++ b/coreff_creditsafe/mixins/creditsafe_data_mixin.py
@@ -167,7 +167,6 @@ class CreditSafeDataMixin(models.AbstractModel):
             rec.zip = company_address.get("postalCode", "")
             if "zip_id" in rec._fields:
                 rec.zip_id = False
-            rec.state_id = self.get_state(company_address.get("province", ""))
             rec.country_id = self.get_country(
                 company_address.get("country", "")
             )
@@ -372,7 +371,6 @@ class CreditSafeDataMixin(models.AbstractModel):
                     "phone": telephone,
                     "type": "other",
                     "title": self.get_title(director.get("title", "")),
-                    "state_id": self.get_state(address.get("province", "")),
                     "country_id": self.get_country(address.get("country", "")),
                 }
             )
@@ -393,19 +391,9 @@ class CreditSafeDataMixin(models.AbstractModel):
         else:
             return False
 
-    def get_state(self, state):
-        # CM: Search for res.country that matches the submitted string
-        if len(state) > 0:
-            result = self.env["res.country.state"].search(
-                [("name", "=", state)]
-            )
-            return result.id
-        else:
-            return False
-
     def get_country(self, country_code):
-        # CM: Search for res.country.state that matches the submitted string
-        # If no match found, use country of parent company
+        # CM: Search for res.country that matches the submitted string
+        # If no match found, use current country from res_partner
         if len(country_code) > 0:
             result = self.env["res.country"].search(
                 [("code", "=", country_code)]


### PR DESCRIPTION
Field "province" in Creditsafe response correspond to then state information in Odoo.

Method get_state tried to find the state in res_country_state by name. This method is error prone. For instance, Spanish state Malaga is returned as 'MALAGA' in province field and stored as 'Málaga' in Odoo.

The better is to never populate the fields.

BTW, a global review of Creditsafe_data_mixin should be done, since the same issue can happen for other list based fields.