### PR TITLE
fix: use street for address streetline directly

### DIFF
--- a/coreff_creditsafe/mixins/creditsafe_data_mixin.py
+++ b/coreff_creditsafe/mixins/creditsafe_data_mixin.py
@@ -155,14 +155,7 @@ class CreditSafeDataMixin(models.AbstractModel):
 
             # CM: Retrieve company address details to override existing
             rec.phone = company_address.get("telephone", "")
-            if len(company_address.get("houseNumber", "")) > 0:
-                rec.street = (
-                    company_address.get("houseNumber", "")
-                    + " "
-                    + company_address.get("street", "")
-                )
-            else:
-                rec.street = company_address.get("street", "")
+            rec.street = company_address.get("street", "")
             rec.city = company_address.get("city", "")
             rec.zip = company_address.get("postalCode", "")
             if "zip_id" in rec._fields:


### PR DESCRIPTION
Creditsafe's street field already contains the houseNumber. Concatenante both fields when houseNumber is available provides a wrong address value.